### PR TITLE
Add a new option for ito.init: limitToFriends

### DIFF
--- a/API.md
+++ b/API.md
@@ -46,6 +46,12 @@ the server location which you have chosen.
 Note: *The default value of SDK URL is `KiiSDK.min.js` in the same directory, since
 Kii Cloud SDK is not available via CDN.*
 
+## Common options
+
+The second argument of `ito.init` can include the following additional options:
+
+- `limitToFriends`: `false` if you want to allow browsers/devices to receive messages from non-friend peers
+
 # Account and Authentication
 
 ## Sign in

--- a/etc/firebase-rules.json
+++ b/etc/firebase-rules.json
@@ -37,13 +37,13 @@
     "messages": {
       "$uid": {
         ".read": "auth != null && auth.uid == $uid",
-        ".write": "auth != null && (!data.exists() || auth.uid == $uid || root.child('friends').child($uid).child(auth.uid).exists())"
+        ".write": "auth != null && (auth.uid == $uid || root.child('users').child($uid).child(auth.uid).exists() || (root.child('users').child($uid).child('limitToFriends').val() == false && root.child('users').child($uid).child('status').val() == 'online'))"
       }
     },
     "signals": {
       "$uid": {
         ".read": "auth != null && auth.uid == $uid",
-        ".write": "auth != null && (!data.exists() || auth.uid == $uid || root.child('friends').child($uid).child(auth.uid).exists())"
+        ".write": "auth != null && (auth.uid == $uid || root.child('users').child($uid).child(auth.uid).exists() || (root.child('users').child($uid).child('limitToFriends').val() == false && root.child('users').child($uid).child('status').val() == 'online'))"
       }
     },
     "notifications": {

--- a/etc/kii-server-code.js
+++ b/etc/kii-server-code.js
@@ -1,3 +1,5 @@
+20 Jul 11:55:19 - Downloading code version 9ephawbs80p897d75p4qdt1gb...
+20 Jul 11:55:19 - Downloaded content: 
 /**
  * ito.js
  * 
@@ -166,7 +168,6 @@ function restrictItoMessage(params, context, done) {
               return object.delete().then(function() { return true; });
           });
         }
-        break;
       case 'email':
         if(object.getID() !== KII_OBJ_EMAIL + user.getID())
           return object.delete();
@@ -176,7 +177,6 @@ function restrictItoMessage(params, context, done) {
         break;
       case 'administrators':
         return object.delete();
-        break;
       }
     });
   }).then(function() {
@@ -429,7 +429,10 @@ function onOffline(params, context, done) {
       var g = KiiGroup.groupWithID(obj.get('group'));
       b = g.bucketWithName(KII_BUCKET_PROFILE);
       o = b.createObjectWithID(KII_OBJ_PROFILE + user.getID());
-      return o.refresh();
+      b = g.bucketWithName(KII_BUCKET_FRIENDS);
+      return kiiSetACLEntry(b, subject.authenticated, action.bucket.create, false).then(function() {
+        return o.refresh();
+      });
     }).then(function(obj) {
       return kiiSetOffline(obj);
     }).then(function() {

--- a/etc/kii-server-code.js
+++ b/etc/kii-server-code.js
@@ -1,5 +1,3 @@
-20 Jul 11:55:19 - Downloading code version 9ephawbs80p897d75p4qdt1gb...
-20 Jul 11:55:19 - Downloaded content: 
 /**
  * ito.js
  * 

--- a/package.json
+++ b/package.json
@@ -1,20 +1,22 @@
 {
   "name": "ito-js",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "ito - browser-to-browser communication library",
   "main": "index.js",
   "dependencies": {
-    "firebase": "^3.6.4",
+    "firebase": "^4.1.0",
     "kii-cloud-sdk": "^2.4.9",
     "mqtt": "^2.2.0",
     "node-localstorage": "^1.3.0"
   },
   "devDependencies": {
-    "babel-cli": "^6.24.0",
-    "babel-preset-env": "^1.2.2"
+    "babel-cli": "^6.24.1",
+    "babel-preset-env": "^1.6.0"
   },
   "babel": {
-    "presets": ["env"]
+    "presets": [
+      "env"
+    ]
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/src-es5/ito-firebase.js
+++ b/src-es5/ito-firebase.js
@@ -45,6 +45,8 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
   var isAdmin = false;
   var passcodesRef = null;
   var passcode = null;
+  var limitToFriendsRef = null;
+  var limitToFriends = true;
 
   var messagesRef = null;
 
@@ -142,7 +144,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
             var h = document.querySelector('head');
             return new Promise(function (resolve, reject) {
               var s = document.createElement('script');
-              s.src = url || 'https://www.gstatic.com/firebasejs/3.8.0/firebase.js';
+              s.src = url || 'https://www.gstatic.com/firebasejs/4.1.3/firebase.js';
               s.addEventListener('load', function () {
                 resolve();
               });
@@ -165,6 +167,7 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
         var _this2 = this;
 
         return new Promise(function (resolve, reject) {
+          limitToFriends = !!arg.limitToFriends;
           initResolve = resolve;
           firebase.initializeApp({
             apiKey: arg.apiKey,
@@ -898,6 +901,10 @@ function _inherits(subClass, superClass) { if (typeof superClass !== "function" 
     disconnectRef = firebase.database().ref('users/' + user.uid + '/status');
     disconnectRef.onDisconnect().remove();
     disconnectRef.onDisconnect().set('offline');
+    limitToFriendsRef = firebase.database().ref('users/' + user.uid + '/limitToFriends');
+    limitToFriendsRef.set(limitToFriends);
+    limitToFriendsRef.onDisconnect().remove();
+    limitToFriendsRef.onDisconnect().set(true);
   }
 
   function firebaseResetOnDisconnectRef() {

--- a/src/ito-firebase.js
+++ b/src/ito-firebase.js
@@ -35,6 +35,8 @@
   let isAdmin = false;
   let passcodesRef = null;
   let passcode = null;
+  let limitToFriendsRef = null;
+  let limitToFriends = true;
 
   let messagesRef = null;
 
@@ -126,7 +128,7 @@
           let h = document.querySelector('head');
           return new Promise((resolve, reject) => {
             let s = document.createElement('script');
-            s.src = url || 'https://www.gstatic.com/firebasejs/3.8.0/firebase.js';
+            s.src = url || 'https://www.gstatic.com/firebasejs/4.1.3/firebase.js';
             s.addEventListener('load', () => { resolve(); });
             s.addEventListener('error', () => {
               reject(new Error('cannot load Firebase SDK'));
@@ -146,6 +148,7 @@
 
     init(arg) {
       return new Promise((resolve, reject) => {
+        limitToFriends = !!arg.limitToFriends;
         initResolve = resolve;
         firebase.initializeApp({
           apiKey: arg.apiKey,
@@ -879,6 +882,10 @@
     disconnectRef = firebase.database().ref('users/' + user.uid + '/status');
     disconnectRef.onDisconnect().remove();
     disconnectRef.onDisconnect().set('offline');
+    limitToFriendsRef = firebase.database().ref('users/' + user.uid + '/limitToFriends');
+    limitToFriendsRef.set(limitToFriends);
+    limitToFriendsRef.onDisconnect().remove();
+    limitToFriendsRef.onDisconnect().set(true);
   }
 
   function firebaseResetOnDisconnectRef() {

--- a/src/ito.js
+++ b/src/ito.js
@@ -65,6 +65,7 @@
   let state = 'uninitialized';
   let profile = {};
   let friends = {};
+  let limitToFriends = true;
   Object.defineProperties(profile, {
     userName: {
       get: () => {
@@ -500,6 +501,7 @@
           reject(new Error('Incorrect Provider'));
         else {
           provider = p;
+          limitToFriends = !!arg.limitToFriends;
 
           // load WebRTC adapter (in the case of web browsers, for now)
           if (isBrowser) {
@@ -601,7 +603,7 @@
      * Client: Messages
      */
     send(uid, msg) {
-      if (!friends[uid])
+      if (!friends[uid] && limitToFriends)
         return Promise.reject(new Error('not registered as a friend: ' + uid));
       else
         return provider.sendMessage(uid, msg);


### PR DESCRIPTION
This PR adds a new option to the second argument of `ito.init`. When the option `limitToFriends` is set to `false`, Ito will accept all messages from any authenticated peer.